### PR TITLE
Small addition to the readme + windows compile error fixed

### DIFF
--- a/Examples/Desktop/Xojo_Sentry/SentryController.xojo_code
+++ b/Examples/Desktop/Xojo_Sentry/SentryController.xojo_code
@@ -654,7 +654,8 @@ Class SentryController
 		    v.UInt32Value(0)=s
 		    if GetFileVersionInfoA("User32.dll",0,s,v) then
 		      if VerQueryValueA(v,"\",r,o) then
-		        dim res As Xojo.Core.MemoryBlock=r
+		        'dim res As Xojo.Core.MemoryBlock=r
+		        dim res As New Xojo.Core.MemoryBlock(r,o)
 		        osinfo.Value("version")=str(res.UInt16Value(18))+"."+str(res.UInt16Value(16))+" "+str(res.UInt16Value(22))+"."+str(res.UInt16Value(20))
 		      end if
 		    end if

--- a/Sentry/Xojo_Sentry/SentryController.xojo_code
+++ b/Sentry/Xojo_Sentry/SentryController.xojo_code
@@ -654,7 +654,8 @@ Class SentryController
 		    v.UInt32Value(0)=s
 		    if GetFileVersionInfoA("User32.dll",0,s,v) then
 		      if VerQueryValueA(v,"\",r,o) then
-		        dim res As Xojo.Core.MemoryBlock=r
+		        'dim res As Xojo.Core.MemoryBlock=r
+		        dim res As New Xojo.Core.MemoryBlock(r,o)
 		        osinfo.Value("version")=str(res.UInt16Value(18))+"."+str(res.UInt16Value(16))+" "+str(res.UInt16Value(22))+"."+str(res.UInt16Value(20))
 		      end if
 		    end if


### PR DESCRIPTION
added usage to the README.md
dim res As Xojo.Core.MemoryBlock=r  on line 243 in SentryController.GenerateJSON caused a compile error on Windows with Xojo 2022r2 (and lower).
replaced it with dim res As New Xojo.Core.MemoryBlock(r,o)
After testing this seems to work.